### PR TITLE
Use component provided config providers.

### DIFF
--- a/docs/book/v2/cookbook/using-zend-form-view-helpers.md
+++ b/docs/book/v2/cookbook/using-zend-form-view-helpers.md
@@ -10,25 +10,36 @@ want to use the various view helpers available in other components, such as:
 By default, only the view helpers directly available in zend-view are available;
 how can you add the others?
 
-To add the zend-form view helpers create a file `config/autoload/zend-form.global.php`
-with the contents:
+## ConfigProvider
+
+When you install zend-form, Composer should prompt you if you want to inject one
+or more `ConfigProvider` classes, including those from zend-hydrator,
+zend-inputfilter, and several others. Always answer "yes" to these; when you do,
+a Composer plugin will add entries for their `ConfigProvider` classes to your
+`config/config.php` file.
+
+If for some reason you are not prompted, or chose "no" when answering the
+prompts, you can add them manually. Add the following entries in the array used
+to create your `ConfigAggregator` instance within `config/config.php`:
 
 ```php
-<?php
-use Zend\Form\ConfigProvider;
-
-$provider = new ConfigProvider();
-return $provider();
+    \Zend\Form\ConfigProvider::class,
+    \Zend\InputFilter\ConfigProvider::class,
+    \Zend\Filter\ConfigProvider::class,
+    \Zend\Validator\ConfigProvider::class,
+    \Zend\Hydrator\ConfigProvider::class,
 ```
-
-and that will essentially do everything needed.
 
 If you installed Expressive via the skeleton, the service
 `Zend\View\HelperPluginManager` is registered for you, and represents the helper
-plugin manager injected into the `PhpRenderer` instance. As such, you only need
-to configure this. The question is: where?
+plugin manager injected into the `PhpRenderer` instance. This instance gets its
+helper configuration from the `view_helpers` top-level configuration key &mdash;
+which the zend-form `ConfigProvider` helps to populate!
 
-You have three options:
+At this point, all view helpers provided by zend-form are registered and ready
+to use.
+
+Alternative options to configure HelperPluginManager:
 
 - Replace the `HelperPluginManager` factory with your own; or
 - Add a delegator factory to or extend the `HelperPluginManager` service to


### PR DESCRIPTION
The provided zend-form component config provider can configure the HelperPluginManager in Expressive v2, as in v3.  It is not essential to replace/delegate/extend the HelperPluginManager factory.

Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [x] Is this related to documentation?
     New Documentation
